### PR TITLE
Mention billing differences with MapLibre GL v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ By default Mapbox styles are referenced by, and include others to mapbox URLs su
 
 Also compatible with react-map-gl.
 
+When upgrading from MapLibre v1 to >= v2 or react-map-gl, and using this transformer, be advised that Mapbox bills tile requests differently from your previous setup. Any library that is not Mapbox GL JS v1.x.x (or its direct fork MapLibre GL v1.x.x), is not anymore billed with Mapbox GL JS "Map Loads", which includes unlimited Vector Tiles API requests ([see pricing docs](https://docs.mapbox.com/mapbox-gl-js/guides/pricing/)). Rather, every (vector) tile request is billed individually. This could make hosting an often-visited map more expensive.
+
 ## Install
 ````
 npm install maplibregl-mapbox-request-transformer --save


### PR DESCRIPTION
I was using this transformer, which allowed me to upgrade to MapLibre GL v2 (thanks!), but wasn't aware of the implications it would have on my Mapbox bill: it significantly increased my costs.  All "Map loads for Web" charges had turned into Vector Tiles API charges.

I figured out why, which I included in this PR to help other people who find this library while inadvertently upgrading their v1 to v2.

As a reference, here's a partially anonymised screen of my billing view to illustrate the effect:

![CleanShot 2023-02-17 at 12 14 40@2x](https://user-images.githubusercontent.com/11543641/219635479-19e998cb-86ce-4df2-86ba-8f0e8cb7b777.png)

And about the Mapbox GL JS included tiles pricing:  https://docs.mapbox.com/mapbox-gl-js/guides/pricing/

![image](https://user-images.githubusercontent.com/11543641/219635597-d97064f7-6d2c-49d5-ad9c-030d73ec670f.png)
